### PR TITLE
Update default.rb for chef 13.x deprecation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-case platform_family
+case node['platform_family']
 when 'debian', 'rhel', 'suse'
   default['user']['home_root'] = '/home'
   default['user']['default_shell'] = '/bin/bash'


### PR DESCRIPTION
method syntax for node attributes was removed in chef 13